### PR TITLE
LimitMEMLOCK=unlimited should be LimitMEMLOCK=infinity

### DIFF
--- a/templates/systemd.unit.j2
+++ b/templates/systemd.unit.j2
@@ -37,7 +37,7 @@ LimitNOFILE=65535
 LimitNPROC=4096
 LimitAS=infinity
 LimitFSIZE=infinity
-LimitMEMLOCK=unlimited
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
"unlimited" should be "infinity" in sysstemd-script.

"unlimited" used on commandline with ulimit -l unlimited.