### PR TITLE
Create opensearch_group as system group

### DIFF
--- a/tasks/install-src.yml
+++ b/tasks/install-src.yml
@@ -4,6 +4,7 @@
 - name: Create opensearch_group
   ansible.builtin.group:
     name: "{{ opensearch_group }}"
+    system: yes
 
 - name: Create opensearch_user
   ansible.builtin.user:


### PR DESCRIPTION
Be consistent when creating the `opensearch_user` and `opensearch_group` with both getting created as system user/group.